### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "any-promise": "^1.1.0",
     "debug": "^2.2.0",
     "joi": "^6.5.0",
-    "node-uuid": "^1.4.3",
     "rainbird-neo4j": "^0.4.3",
     "tap-debug": "^0.1.4",
-    "thenify-all": "^1.6.0"
+    "thenify-all": "^1.6.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "jshint": "latest",

--- a/src/node.js
+++ b/src/node.js
@@ -7,7 +7,7 @@ var responseParser = require('./response-parser'),
 var Joi = require('joi'),
     Promise = require('any-promise'),
     util = require('util'),
-    uuid = require('node-uuid');
+    uuid = require('uuid');
 
 var debug = require('debug')('neo4j-simple:node'),
     see = require('tap-debug')(debug);

--- a/src/relationship.js
+++ b/src/relationship.js
@@ -7,7 +7,7 @@ var responseParser = require('./response-parser'),
 var Joi = require('joi'),
     Promise = require('any-promise'),
     util = require('util'),
-    uuid = require('node-uuid');
+    uuid = require('uuid');
 
 var debug = require('debug')('neo4j-simple:relationship'),
     see = require('tap-debug')(debug);


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.